### PR TITLE
Don't take failed jobs into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 1.0.2 - 2021-05-06
+## 1.0.3 - 2021-05-06
 ### Fixed
 - Don't take failed jobs into account
+
+## 1.0.2 - 2021-03-04
+### Added
+- Added PHP8 support
 
 ## 1.0.1 - 2020-03-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2 - 2021-05-06
+### Fixed
+- Don't take failed jobs into account
+
 ## 1.0.1 - 2020-03-19
 ### Fixed
 - Take all jobs into account, not only pending jobs

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "name": "nerds-and-company/craft-hirefire",
     "description": "Hirefire.io worker scheduler for Craft 3 queue jobs",
     "type": "craft-plugin",

--- a/src/controllers/InfoController.php
+++ b/src/controllers/InfoController.php
@@ -33,10 +33,12 @@ class InfoController extends Controller
             throw new UserException(Craft::t('hirefire', 'Invalid Hirefire token.'));
         }
 
+        $queue = Craft::$app->queue;
+
         // Return pending queue for worker
         return $this->asJson([[
             'name' => 'worker',
-            'quantity' => Craft::$app->queue->getTotalJobs(),
+            'quantity' => $queue->getTotalJobs() - $queue->getTotalFailed(),
         ]]);
     }
 }


### PR DESCRIPTION
Or hirefire will always keep a running worker for jobs that have failed